### PR TITLE
popover menu download and upload numbers swap

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -37,7 +37,6 @@ namespace WingpanelMonitor {
 
         construct {
             valign = Gtk.Align.CENTER;
-            margin_top = 4;
 
 
             cpu_info = new IndicatorWidget ("cpu-symbolic", 4);

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -109,8 +109,8 @@ namespace WingpanelMonitor {
         }
 
         public void update_network (int upload, int download) {
-            network_down.label_value = Utils.format_net_speed (upload, true, false);
-            network_up.label_value = Utils.format_net_speed (download, true, false);
+            network_down.label_value = Utils.format_net_speed (download, true, false);
+            network_up.label_value = Utils.format_net_speed (upload, true, false);
         }
     }
 }


### PR DESCRIPTION
Hi, Thanks for your useful indicator application.

In the PopOver menu, Network Down and Network Up speed numbers were used In reverse. so I made a very small fix for that.

Screenshot:
![Screenshot from 2020-12-14 12-44-38](https://user-images.githubusercontent.com/18558954/102079666-5ae99600-3e22-11eb-81e2-022beb9967d7.png)
