### PR TITLE
popover download and upload numbers swap, Indicator margin fix

### DIFF
--- a/src/Widgets/DisplayWidget.vala
+++ b/src/Widgets/DisplayWidget.vala
@@ -37,7 +37,6 @@ namespace WingpanelMonitor {
 
         construct {
             valign = Gtk.Align.CENTER;
-            margin_top = 4;
 
 
             cpu_info = new IndicatorWidget ("cpu-symbolic", 4);

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -69,8 +69,8 @@ namespace WingpanelMonitor {
             add (ram);
             add (swap);
             add (uptime);
-            add (network_down);
             add (network_up);
+            add (network_down);
             add (new Wingpanel.Widgets.Separator ());
             add (hide_button);
             add (settings_button);
@@ -109,8 +109,8 @@ namespace WingpanelMonitor {
         }
 
         public void update_network (int upload, int download) {
-            network_down.label_value = Utils.format_net_speed (upload, true, false);
-            network_up.label_value = Utils.format_net_speed (download, true, false);
+            network_down.label_value = Utils.format_net_speed (download, true, false);
+            network_up.label_value = Utils.format_net_speed (upload, true, false);
         }
     }
 }


### PR DESCRIPTION
Hi, Thanks for your useful indicator application.

1. In the PopOver menu, Network Down and Network Up speed numbers were used In reverse. so I made a very small fix for that.
2. By default Indicator is now centered and margin_top is not needed anymore. (as it's shown in the first screenshot Indicator is showing a bit lower than other Indicators.

Screenshot before changes:
![Screenshot from 2020-12-14 12-44-38](https://user-images.githubusercontent.com/18558954/102099553-a3fb1380-3e3d-11eb-8ace-b2defeca2e02.png)

Screenshot after changes:
![Screenshot from 2020-12-14 18-52-36](https://user-images.githubusercontent.com/18558954/102099595-aeb5a880-3e3d-11eb-8576-2105131d8f7e.png)

*PS: Commits got messed up in my previous PR, So I made this one. Sorry about that :sweat_smile: