### PR TITLE
Elementary 6.0 Odin compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,24 @@ libglib2.0-dev
 libgtop2-dev
 libgranite-dev
 libgtk-3-dev
-libwingpanel-2.0-dev
+libwingpanel-3.0-dev
 libgeoclue-2-dev
 libgweather-3-dev
 meson
 valac
 ```
 
-You can install them running
-```
+You can install them: 
+
+- Version Hera (elementary 5.x.x):
+```bash
 sudo apt install libgtop2-dev libgranite-dev libgtk-3-dev libwingpanel-2.0-dev meson valac libgeoclue-2-dev libgweather-3-dev
 ```
 
+- version Odin (elementary 6.x.x):
+```bash
+sudo apt install libgtop2-dev libgranite-dev libgtk-3-dev libwingpanel-3.0-dev meson valac libgeoclue-2-dev libgweather-3-dev
+```
 Run `meson` to configure the build environment and then `ninja` to build
 
 ```

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 10),
                libgranite-dev,
                libgtop2-dev,
                libgtk-3-dev (>= 3.12),
-               libwingpanel-2.0-dev,
+               libwingpanel-3.0-dev,
                meson,
                valac (>= 0.34)
 Standards-Version: 3.9.7

--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,10 @@ libdir = join_paths(prefix, get_option('libdir'))
 icondir = join_paths(datadir, 'icons', 'hicolor')
 
 # deps
-wingpanel = dependency('wingpanel-2.0')
+wingpanel= dependency('wingpanel-2.0',required : false)
+if not wingpanel.found()
+    wingpanel = dependency('wingpanel',required : true)
+endif
 
 icons_gresource = gnome.compile_resources(
     'gresource_icons',

--- a/src/Indicator.vala
+++ b/src/Indicator.vala
@@ -36,10 +36,8 @@ namespace WingpanelMonitor {
 
         public Indicator (Wingpanel.IndicatorManager.ServerType server_type) {
             Object (
-                code_name: APPNAME,
-                display_name: "Wingpanel-Monitor",
-                description: "System monitor indicator for Wingpanel"
-                );
+                code_name: APPNAME
+            );
         }
 
         construct {

--- a/src/Widgets/PopoverWidget.vala
+++ b/src/Widgets/PopoverWidget.vala
@@ -64,14 +64,14 @@ namespace WingpanelMonitor {
 
 
             add (title_label);
-            add (new Wingpanel.Widgets.Separator ());
+            add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             add (cpu_freq);
             add (ram);
             add (swap);
             add (uptime);
             add (network_up);
             add (network_down);
-            add (new Wingpanel.Widgets.Separator ());
+            add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             add (hide_button);
             add (settings_button);
         }

--- a/src/Widgets/Toggles.vala
+++ b/src/Widgets/Toggles.vala
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2020 Tudor Plugaru (https://github.com/PlugaruT/wingpanel-monitor)
+ * Copyright (c) 2021 Tudor Plugaru (https://github.com/PlugaruT/wingpanel-monitor)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -17,19 +17,20 @@
  * Boston, MA 02110-1301 USA.
  *
  * Authored by: Tudor Plugaru <plugaru.tudor@gmail.com>
+ *              Anderson Laverde <anderson.laverde@zohomail.com>
  */
 
 namespace WingpanelMonitor {
     public class TogglesWidget : Gtk.Grid {
-        private Wingpanel.Widgets.Switch cpu_switch;
-        private Wingpanel.Widgets.Switch ram_switch;
-        private Wingpanel.Widgets.Switch network_switch;
-        private Wingpanel.Widgets.Switch workspace_switch;
-        private Wingpanel.Widgets.Switch weather_switch;
-        private Wingpanel.Widgets.Switch icon_only_switch;
-        private Wingpanel.Widgets.Switch indicator;
+        private Granite.SwitchModelButton cpu_switch;
+        private Granite.SwitchModelButton ram_switch;
+        private Granite.SwitchModelButton network_switch;
+        private Granite.SwitchModelButton workspace_switch;
+        private Granite.SwitchModelButton weather_switch;
+        private Granite.SwitchModelButton icon_only_switch;
+        private Granite.SwitchModelButton indicator;
         private SpinRow weather_refresh_spin;
-        public unowned Settings settings { get; construct set; }
+        public unowned Settings settings { get; set; }
 
         public TogglesWidget (Settings settings) {
             Object (settings: settings, hexpand: true);
@@ -37,28 +38,35 @@ namespace WingpanelMonitor {
 
         construct {
             orientation = Gtk.Orientation.VERTICAL;
-
-            icon_only_switch = new Wingpanel.Widgets.Switch ("Show icon", settings.get_boolean ("icon-only"));
-            cpu_switch = new Wingpanel.Widgets.Switch ("CPU usage", settings.get_boolean ("show-cpu"));
-            ram_switch = new Wingpanel.Widgets.Switch ("RAM usage", settings.get_boolean ("show-ram"));
-            network_switch = new Wingpanel.Widgets.Switch ("Network usage", settings.get_boolean ("show-network"));
-            workspace_switch = new Wingpanel.Widgets.Switch (
-                "Workspace number", settings.get_boolean ("show-workspace")
-                );
-            weather_switch = new Wingpanel.Widgets.Switch (
-                "Weather for %s".printf (settings.get_string ("weather-location")),
-                settings.get_boolean ("show-weather")
-                );
-            indicator = new Wingpanel.Widgets.Switch ("ON/OFF", settings.get_boolean ("display-indicator"));
-
-            settings.bind ("display-indicator", indicator.get_switch (), "active", SettingsBindFlags.DEFAULT);
-
-            settings.bind ("show-cpu", cpu_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
-            settings.bind ("show-ram", ram_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
-            settings.bind ("show-network", network_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
-            settings.bind ("show-workspace", workspace_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
-            settings.bind ("show-weather", weather_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
-            settings.bind ("icon-only", icon_only_switch.get_switch (), "active", SettingsBindFlags.DEFAULT);
+            indicator = new Granite.SwitchModelButton ("ON/OFF") {
+                active = settings.get_boolean ("display-indicator")
+            };
+            cpu_switch = new Granite.SwitchModelButton ("CPU usage") {
+                active = settings.get_boolean ("show-cpu")
+            };
+            icon_only_switch = new Granite.SwitchModelButton ("Show icon") {
+                active = settings.get_boolean ("icon-only")
+            };
+            ram_switch = new Granite.SwitchModelButton ("RAM usage") {
+                active = settings.get_boolean ("show-ram")
+            };
+            network_switch = new Granite.SwitchModelButton ("Network usage") {
+                active = settings.get_boolean ("show-network")
+            };
+            workspace_switch = new Granite.SwitchModelButton ("Workspace number") {
+                active = settings.get_boolean ("show-workspace")
+            };
+            weather_switch = new Granite.SwitchModelButton ("Weather for %s".printf (settings.get_string ("weather-location"))) {
+                active = settings.get_boolean ("show-weather")
+            };
+            
+            settings.bind ("display-indicator", indicator, "active", SettingsBindFlags.DEFAULT);
+            settings.bind ("show-cpu", cpu_switch, "active", SettingsBindFlags.DEFAULT);
+            settings.bind ("show-ram", ram_switch, "active", SettingsBindFlags.DEFAULT);
+            settings.bind ("show-network", network_switch, "active", SettingsBindFlags.DEFAULT);
+            settings.bind ("show-workspace", workspace_switch, "active", SettingsBindFlags.DEFAULT);
+            settings.bind ("show-weather", weather_switch, "active", SettingsBindFlags.DEFAULT);
+            settings.bind ("icon-only", icon_only_switch, "active", SettingsBindFlags.DEFAULT);
 
 
             weather_refresh_spin = new SpinRow ("Weather refresh rate (min)", 1, 60);
@@ -68,15 +76,15 @@ namespace WingpanelMonitor {
             });
 
             add (indicator);
-            add (new Wingpanel.Widgets.Separator ());
+            add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             add (icon_only_switch);
             add (cpu_switch);
             add (ram_switch);
             add (network_switch);
             add (workspace_switch);
             add (weather_switch);
+            add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             add (weather_refresh_spin);
-            add (new Wingpanel.Widgets.Separator ());
         }
     }
 }


### PR DESCRIPTION
I just add small tweaks to make this awesome wingpanel indicator works in elementary os 6.0 

If you have any comments let me know

Todo: 
- Remove some deprecations but works fine
```
./src/Widgets/PopoverWidget.vala:67.22-67.48: warning: `Wingpanel.Widgets.Separator' has been deprecated since 3.0.0. Use Gtk.Separator

../src/Widgets/Toggles.vala:24.9-24.51: warning: `Wingpanel.Widgets.Switch' has been deprecated since 3.0.0. Use Granite.SwitchModelButton

```
![Screenshot from 2021-05-18 11-45-12](https://user-images.githubusercontent.com/22928302/118691294-8a843c00-b7ce-11eb-918e-d2d56ad44617.png)
